### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8",
+    "phpunit/phpunit": "^4.8.36",
     "scrutinizer/ocular": "~1.2",
-    "satooshi/php-coveralls": "^1.0"
+    "php-coveralls/php-coveralls": "^1.0"
   }
 }

--- a/tests/Analyzer/FrequencyTest.php
+++ b/tests/Analyzer/FrequencyTest.php
@@ -4,8 +4,9 @@ namespace AnalyzerText\Tests\Analyzer;
 
 use AnalyzerText\Analyzer\Frequency;
 use AnalyzerText\Text;
+use PHPUnit\Framework\TestCase;
 
-class FrequencyTest extends \PHPUnit_Framework_TestCase
+class FrequencyTest extends TestCase
 {
     /**
      * @var Frequency

--- a/tests/Filter/FactoryTest.php
+++ b/tests/Filter/FactoryTest.php
@@ -6,8 +6,9 @@ use AnalyzerText\Analyzer\Analyzer;
 use AnalyzerText\Analyzer\Frequency;
 use AnalyzerText\Filter\Factory;
 use AnalyzerText\Text;
+use PHPUnit\Framework\TestCase;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     /**
      * @var Factory

--- a/tests/Text/WordTest.php
+++ b/tests/Text/WordTest.php
@@ -3,8 +3,9 @@
 namespace AnalyzerText\Tests\Text;
 
 use AnalyzerText\Text\Word;
+use PHPUnit\Framework\TestCase;
 
-class WordTest extends \PHPUnit_Framework_TestCase
+class WordTest extends TestCase
 {
     public function test()
     {

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -4,8 +4,9 @@ namespace AnalyzerText\Tests;
 
 use AnalyzerText\Text;
 use AnalyzerText\Text\Word;
+use PHPUnit\Framework\TestCase;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends TestCase
 {
     /**
      * @return array


### PR DESCRIPTION
# Changed log
- The `satooshi/php-coveralls` package. Using the `php-coveralls/php-coveralls` instead.
- To support future stable `PHPUnit` version, using the `PHPUnit\Framework\TestCase` namespace.
- Using the final `PHPUnit` `4.8` version and it can be easy to migrate to latest stable `PHPUnit` version in the future.